### PR TITLE
fix: movies footer mobile layout and half-star rendering (VIC-46)

### DIFF
--- a/pages/movies.tsx
+++ b/pages/movies.tsx
@@ -87,18 +87,17 @@ function StarRow({ rating }: { rating: number }) {
       {Array.from({ length: full }).map((_, i) => (
         <span key={`f${i}`} style={{ color: "hsl(var(--accent-secondary))", fontSize: "1em", lineHeight: 1 }}>★</span>
       ))}
-      {/* Half star: two overlapping stars, clipped */}
+      {/* Half star: two overlapping stars, right half clipped */}
       {half && (
-        <span style={{ position: "relative", display: "inline-block", width: "0.6em", lineHeight: 1 }}>
+        <span style={{ position: "relative", display: "inline-block", width: "1em", lineHeight: 1 }}>
           {/* Empty background */}
           <span style={{ color: "hsl(var(--accent-secondary) / 0.25)", fontSize: "1em", lineHeight: 1 }}>★</span>
-          {/* Filled half — clipped to left 50% */}
+          {/* Filled half — clip-path removes right 50% of the glyph */}
           <span style={{
             position: "absolute",
             left: 0,
             top: 0,
-            overflow: "hidden",
-            width: "50%",
+            clipPath: "inset(0 50% 0 0)",
             color: "hsl(var(--accent-secondary))",
             fontSize: "1em",
             lineHeight: 1,
@@ -331,7 +330,7 @@ export default function MoviesPage({ movies }: Props) {
 
         {/* Footer */}
         <div
-          className="mt-10 flex items-center justify-between fade-in-up"
+          className="mt-10 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-0 fade-in-up"
           style={{ animationDelay: "500ms" }}
         >
           <a


### PR DESCRIPTION
## Summary

- **Movies footer mobile layout:** On mobile the \"View my full Letterboxd profile\" link and \"5 recent reviews\" count were touching side-by-side. Changed to \`flex-col-reverse\` on mobile so the count appears above the link as a clean column. \`sm:flex-row sm:justify-between\` restores the original row layout on tablet/desktop.
- **VIC-46 — Half star bug:** The half star container was \`width: 0.6em\` and the filled overlay used \`overflow: hidden; width: 50%\` (= 0.3em), which only filled ~30% of the visual star. Fixed by replacing the overflow clip with \`clip-path: inset(0 50% 0 0)\` — this removes exactly the right 50% of the glyph regardless of container width. Container widened to \`1em\` to match full stars.

## Test plan
- [ ] Movies page mobile (375px): verify "5 recent reviews" appears above the profile link
- [ ] Movies page desktop: verify footer remains a single row (link left, count right)
- [ ] Any movie with a half-star rating: verify the half star fills exactly the left half of the glyph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: adjusts CSS clipping for half-star rendering and tweaks footer flex layout on small screens, with no data or logic changes.
> 
> **Overview**
> Fixes half-star rendering on the Movies page by switching the overlay from `overflow/width` clipping to `clip-path: inset(0 50% 0 0)` and widening the half-star container so the filled portion consistently covers exactly half the glyph.
> 
> Improves the footer’s mobile layout by stacking the profile link and “recent reviews” count (`flex-col-reverse` with spacing) while preserving the original horizontal alignment on `sm+` breakpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9189cbe0c4dbeac64045727a704b09c9418bfe29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->