### PR TITLE
fix: force text presentation for heart icon on Safari

### DIFF
--- a/pages/movies.tsx
+++ b/pages/movies.tsx
@@ -294,7 +294,7 @@ function StatsSection({ stats }: { stats: Stats }) {
     {
       label: "liked",
       value: String(stats.likedCount),
-      suffix: " ♥",
+      suffix: " ♥\uFE0E",
     },
   ];
 
@@ -472,7 +472,7 @@ function MovieCard({ movie, index }: { movie: Movie; index: number }) {
                   style={{ ...STAR_SLOT, color: "hsl(var(--accent-secondary))" }}
                   title="Liked"
                 >
-                  ♥
+                  {"♥\uFE0E"}
                 </span>
               )}
               <StarRow rating={movie.rating} />


### PR DESCRIPTION
## Summary
- Appends Unicode Variation Selector-15 (`\uFE0E`) after each `♥` (U+2665) on the movies page
- Affects two spots: the liked badge on individual movie cards, and the stats chip suffix
- Fixes Safari rendering the heart as a color emoji (Apple Color Emoji), which ignores CSS `color`

## Root cause
Safari defaults to emoji presentation for U+2665 (♥), substituting the Apple Color Emoji glyph which is not colorable via CSS. Chrome already renders it as a text symbol. VS-15 (`\uFE0E`) explicitly requests text presentation on all browsers.

## Test plan
- [ ] Open `/movies` on Safari — heart should appear in coral-red, matching the stars
- [ ] Open `/movies` on Chrome — no regression, heart still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)