### PR TITLE
Footer improvements: icons, nav links, layout, credits

### DIFF
--- a/components/art/expandedArt.tsx
+++ b/components/art/expandedArt.tsx
@@ -11,6 +11,7 @@ export interface ExpandedArtProps {
 }
 
 export function ExpandedArt(props: ExpandedArtProps) {
+  const { onClose } = props;
   const [currentIndex, setCurrentIndex] = useState(props.currentIndex);
   const [currArt, setCurrArt] = useState(props.art);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -41,7 +42,7 @@ export function ExpandedArt(props: ExpandedArtProps) {
 
     // Keyboard navigation
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") props.onClose();
+      if (e.key === "Escape") onClose();
       if (e.key === "ArrowLeft") goToPrevious();
       if (e.key === "ArrowRight") goToNext();
     };
@@ -52,7 +53,7 @@ export function ExpandedArt(props: ExpandedArtProps) {
       document.body.style.overflow = "auto";
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [props.onClose, goToPrevious, goToNext]);
+  }, [onClose, goToPrevious, goToNext]);
 
   return (
     <div

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -6,6 +6,30 @@ import {
 } from "../model/constants";
 import { useState } from "react";
 import { Check, Copy, Github, Linkedin } from "lucide-react";
+import Link from "next/link";
+
+const NAV_LINKS = [
+  { href: "/",         label: "About",    accent: "--accent"          },
+  { href: "/projects", label: "Projects", accent: "--accent-projects" },
+  { href: "/blog",     label: "Blog",     accent: "--accent-blog"     },
+  { href: "/art",      label: "Art",      accent: "--accent-tertiary" },
+  { href: "/movies",   label: "Movies",   accent: "--accent-secondary"},
+];
+
+function FooterNavLink({ href, label, accent }: { href: string; label: string; accent: string }) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Link
+      href={href}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{ color: hovered ? `hsl(var(${accent}))` : undefined }}
+      className="text-sm font-mono tracking-wide text-[hsl(var(--text-secondary))] transition-colors duration-150"
+    >
+      {label}
+    </Link>
+  );
+}
 
 export interface FooterProps {}
 
@@ -99,6 +123,13 @@ export function Footer(props: FooterProps) {
             </a>
           </div>
         </div>
+
+        {/* Nav Links */}
+        <nav aria-label="Footer navigation" className="flex flex-wrap gap-x-8 gap-y-3 mb-12">
+          {NAV_LINKS.map((item) => (
+            <FooterNavLink key={item.href} {...item} />
+          ))}
+        </nav>
 
         {/* Divider */}
         <div className="h-px bg-[hsl(var(--border))] mb-8" />

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,7 +5,7 @@ import {
   LINKEDIN_URL,
 } from "../model/constants";
 import { useState } from "react";
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, Github, Linkedin } from "lucide-react";
 
 export interface FooterProps {}
 
@@ -54,38 +54,48 @@ export function Footer(props: FooterProps) {
           </div>
 
           {/* Social Links */}
-          <div className="flex gap-6">
+          <div className="flex gap-5">
             <a
               href={X_TWITTER_URL}
               target="_blank"
               rel="noreferrer"
-              className="group flex items-center gap-2 text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
+              aria-label="X (Twitter)"
+              className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
             >
-              <span className="font-medium">X</span>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622Zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+              </svg>
             </a>
             <a
               href={INSTAGRAM_URL}
               target="_blank"
               rel="noreferrer"
-              className="group flex items-center gap-2 text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
+              aria-label="Instagram"
+              className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
             >
-              <span className="font-medium">IG</span>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+                <circle cx="12" cy="12" r="4" />
+                <circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none" />
+              </svg>
             </a>
             <a
               href={GITHUB_URL}
               target="_blank"
               rel="noreferrer"
-              className="group flex items-center gap-2 text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
+              aria-label="GitHub"
+              className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
             >
-              <span className="font-medium">GH</span>
+              <Github size={18} aria-hidden="true" />
             </a>
             <a
               href={LINKEDIN_URL}
               target="_blank"
               rel="noreferrer"
-              className="group flex items-center gap-2 text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
+              aria-label="LinkedIn"
+              className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
             >
-              <span className="font-medium">LN</span>
+              <Linkedin size={18} aria-hidden="true" />
             </a>
           </div>
         </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -9,11 +9,11 @@ import { Check, Copy, Github, Linkedin } from "lucide-react";
 import Link from "next/link";
 
 const NAV_LINKS = [
-  { href: "/",         label: "About",    accent: "--accent"          },
-  { href: "/projects", label: "Projects", accent: "--accent-projects" },
-  { href: "/blog",     label: "Blog",     accent: "--accent-blog"     },
-  { href: "/art",      label: "Art",      accent: "--accent-tertiary" },
-  { href: "/movies",   label: "Movies",   accent: "--accent-secondary"},
+  { href: "/",         label: "About",    accent: "--accent"           },
+  { href: "/projects", label: "Projects", accent: "--accent-projects"  },
+  { href: "/blog",     label: "Blog",     accent: "--accent-blog"      },
+  { href: "/art",      label: "Art",      accent: "--accent-tertiary"  },
+  { href: "/movies",   label: "Movies",   accent: "--accent-secondary" },
 ];
 
 function FooterNavLink({ href, label, accent }: { href: string; label: string; accent: string }) {
@@ -48,101 +48,118 @@ export function Footer(props: FooterProps) {
   };
 
   return (
-    <footer className="py-16 md:py-24 border-t border-[hsl(var(--border))]">
+    <footer className="pt-16 pb-10 md:pt-24 md:pb-12 border-t border-[hsl(var(--border))]">
       <div className="max-w-6xl mx-auto px-6">
-        {/* Top Section */}
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-8 mb-12">
-          {/* Email */}
-          <div>
-            <p className="text-sm text-[hsl(var(--text-secondary))] mb-2">
-              Say Hello
-            </p>
-            <button
-              onClick={handleCopyEmail}
-              className="group flex items-center gap-3 text-xl md:text-2xl font-display text-[hsl(var(--foreground))] hover:text-[hsl(var(--accent))] transition-colors"
-            >
-              {email}
-              <span className="p-2 rounded-lg bg-[hsl(var(--surface))] border border-[hsl(var(--border))] group-hover:border-[hsl(var(--accent)/0.3)] transition-colors">
-                {copied ? (
-                  <Check className="w-4 h-4 text-[hsl(var(--accent))]" />
-                ) : (
-                  <Copy className="w-4 h-4" />
-                )}
-              </span>
-            </button>
-            {copied && (
-              <p className="text-sm text-[hsl(var(--accent))] mt-2 font-mono">
-                Copied to clipboard!
+
+        {/* Main grid: contact left, navigate right */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-16 mb-12 md:mb-16">
+
+          {/* Left: contact + social */}
+          <div className="flex flex-col gap-8">
+            {/* Email */}
+            <div>
+              <p className="text-xs font-mono tracking-widest uppercase text-[hsl(var(--text-secondary))] mb-3">
+                Say Hello
               </p>
-            )}
+              <button
+                onClick={handleCopyEmail}
+                className="group flex items-center gap-3 text-lg md:text-xl font-display text-[hsl(var(--foreground))] hover:text-[hsl(var(--accent))] transition-colors"
+              >
+                {email}
+                <span className="p-1.5 rounded-lg bg-[hsl(var(--surface))] border border-[hsl(var(--border))] group-hover:border-[hsl(var(--accent)/0.3)] transition-colors">
+                  {copied ? (
+                    <Check className="w-3.5 h-3.5 text-[hsl(var(--accent))]" />
+                  ) : (
+                    <Copy className="w-3.5 h-3.5" />
+                  )}
+                </span>
+              </button>
+              {copied && (
+                <p className="text-xs text-[hsl(var(--accent))] mt-2 font-mono">
+                  Copied to clipboard!
+                </p>
+              )}
+            </div>
+
+            {/* Social icons */}
+            <div>
+              <p className="text-xs font-mono tracking-widest uppercase text-[hsl(var(--text-secondary))] mb-3">
+                Follow
+              </p>
+              <div className="flex gap-5">
+                <a
+                  href={X_TWITTER_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="X (Twitter)"
+                  className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622Zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                  </svg>
+                </a>
+                <a
+                  href={INSTAGRAM_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="Instagram"
+                  className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+                    <circle cx="12" cy="12" r="4" />
+                    <circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none" />
+                  </svg>
+                </a>
+                <a
+                  href={GITHUB_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="GitHub"
+                  className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
+                >
+                  <Github size={18} aria-hidden="true" />
+                </a>
+                <a
+                  href={LINKEDIN_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="LinkedIn"
+                  className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
+                >
+                  <Linkedin size={18} aria-hidden="true" />
+                </a>
+              </div>
+            </div>
           </div>
 
-          {/* Social Links */}
-          <div className="flex gap-5">
-            <a
-              href={X_TWITTER_URL}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="X (Twitter)"
-              className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622Zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-              </svg>
-            </a>
-            <a
-              href={INSTAGRAM_URL}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Instagram"
-              className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
-            >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
-                <circle cx="12" cy="12" r="4" />
-                <circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none" />
-              </svg>
-            </a>
-            <a
-              href={GITHUB_URL}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="GitHub"
-              className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
-            >
-              <Github size={18} aria-hidden="true" />
-            </a>
-            <a
-              href={LINKEDIN_URL}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="LinkedIn"
-              className="text-[hsl(var(--text-secondary))] hover:text-[hsl(var(--accent))] transition-colors"
-            >
-              <Linkedin size={18} aria-hidden="true" />
-            </a>
+          {/* Right: navigate */}
+          <div>
+            <p className="text-xs font-mono tracking-widest uppercase text-[hsl(var(--text-secondary))] mb-4">
+              Navigate
+            </p>
+            <nav aria-label="Footer navigation" className="flex flex-wrap gap-x-8 gap-y-3">
+              {NAV_LINKS.map((item) => (
+                <FooterNavLink key={item.href} {...item} />
+              ))}
+            </nav>
           </div>
+
         </div>
-
-        {/* Nav Links */}
-        <nav aria-label="Footer navigation" className="flex flex-wrap gap-x-8 gap-y-3 mb-12">
-          {NAV_LINKS.map((item) => (
-            <FooterNavLink key={item.href} {...item} />
-          ))}
-        </nav>
 
         {/* Divider */}
         <div className="h-px bg-[hsl(var(--border))] mb-8" />
 
-        {/* Bottom Section */}
-        <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-          <p className="text-sm font-mono text-[hsl(var(--text-secondary))]">
+        {/* Bottom bar */}
+        <div className="flex flex-col md:flex-row justify-between items-center gap-2 text-center">
+          <p className="text-xs font-mono text-[hsl(var(--text-secondary))]">
             &copy; Victor Gomes {new Date().getFullYear()}
           </p>
-          <p className="text-sm text-[hsl(var(--text-muted))]">
-            Built with Next.js & Tailwind CSS
+          <p className="text-xs font-mono text-[hsl(var(--text-secondary))] opacity-50">
+            Built with Next.js · Deployed on Vercel
           </p>
         </div>
+
       </div>
     </footer>
   );

--- a/components/home/aboutSnapshot.tsx
+++ b/components/home/aboutSnapshot.tsx
@@ -59,7 +59,7 @@ export function AboutSnapshot() {
             className={`${isVisible ? "fade-in-up stagger-2" : "opacity-0"}`}
           >
             <p className="text-[hsl(var(--text-secondary))] text-base md:text-lg leading-relaxed mb-6">
-              I'm a senior front-end engineer with a sharp eye for design and
+              I&apos;m a senior front-end engineer with a sharp eye for design and
               product. I believe great products are technically solid and
               visually refined. My passion for art is a big part of why.
             </p>

--- a/components/home/aboutSnapshot.tsx
+++ b/components/home/aboutSnapshot.tsx
@@ -45,9 +45,11 @@ export function AboutSnapshot() {
           {/* Left - Pull Quote */}
           <div className={`${isVisible ? "fade-in-up" : "opacity-0"}`}>
             <blockquote className="text-2xl md:text-3xl lg:text-4xl font-display leading-snug text-[hsl(var(--foreground))]">
-              &ldquo;I love building things, especially digital experiences that
-              feel <span className="text-[hsl(var(--accent))]">beautiful</span>{" "}
-              and delightful.&rdquo;
+              &ldquo;Great products need{" "}
+              <span className="text-[hsl(var(--accent))]">
+                speed, polish, and soul
+              </span>
+              . I refuse to pick only two.&rdquo;
             </blockquote>
             <div className="mt-6 h-1 w-16 bg-[hsl(var(--accent))]" />
           </div>
@@ -57,16 +59,15 @@ export function AboutSnapshot() {
             className={`${isVisible ? "fade-in-up stagger-2" : "opacity-0"}`}
           >
             <p className="text-[hsl(var(--text-secondary))] text-base md:text-lg leading-relaxed mb-6">
-              A senior front-end engineer with a sharp eye for design and
-              product. The best digital products are technically solid{" "}
-              <em>and</em> visually refined, and my passion for making and
-              appreciating art is a big part of why.
+              I'm a senior front-end engineer with a sharp eye for design and
+              product. I believe great products are technically solid and
+              visually refined. My passion for art is a big part of why.
             </p>
             <p className="text-[hsl(var(--text-secondary))] text-base md:text-lg leading-relaxed">
               Originally from Brazil, grew up gaming, drawing, and staying
               active. Outside of engineering, you&apos;ll find me on the soccer
-              field, at the ping pong table, or lifting some weights. That same
-              restless energy is what makes me obsess over every pixel.
+              field, running, at the local jazz bar, or traveling and exploring
+              new places.
             </p>
           </div>
         </div>

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,5 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap');
-@import url('https://api.fontshare.com/v2/css?f[]=clash-display@400,500,600,700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap");
+@import url("https://api.fontshare.com/v2/css?f[]=clash-display@400,500,600,700&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -10,27 +10,27 @@
   --background: 222 20% 4%; /* #080A0F */
   --background-rgb: 8, 10, 15;
   --foreground: 220 30% 94%; /* #E8EDF5 */
-  
+
   --surface: 222 18% 7%; /* #0F1117 */
   --surface-elevated: 222 20% 12%; /* #161B27 */
   --surface-rgb: 15, 17, 23;
-  
+
   --border: 220 22% 16%; /* #1E2535 */
   --border-subtle: 220 22% 12%;
-  
+
   --accent: 166 100% 70%; /* #64FFDA - Electric Mint */
   --accent-rgb: 100, 255, 218;
   --accent-foreground: 222 20% 4%;
-  
+
   --accent-secondary: 0 100% 71%; /* #FF6B6B - Coral Red */
   --accent-tertiary: 270 78% 75%; /* #C084FC - Soft Violet */
   --accent-blog: 213 100% 65%; /* #4DB8FF - Neon Blue */
   --accent-projects: 152 68% 48%; /* #26C17E - Emerald Green */
-  
+
   --text-primary: 220 30% 94%; /* #E8EDF5 */
-  --text-secondary: 220 20% 51%; /* #6B7A99 */
+  --text-secondary: 220 12% 66%; /* #9AA3B5 */
   --text-muted: 220 15% 40%;
-  
+
   --card: 222 18% 7%;
   --card-foreground: 220 30% 94%;
   --popover: 222 18% 7%;
@@ -46,7 +46,7 @@
   --input: 220 22% 16%;
   --ring: 166 100% 70%;
   --radius: 0.75rem;
-  
+
   /* Chart colors */
   --chart-1: 166 100% 70%;
   --chart-2: 0 100% 71%;
@@ -59,33 +59,42 @@
   * {
     @apply border-border;
   }
-  
+
   html {
     scroll-behavior: smooth;
   }
-  
+
   body {
     @apply bg-background text-foreground antialiased;
-    font-family: 'DM Sans', sans-serif;
+    font-family: "DM Sans", sans-serif;
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
   }
-  
-  h1, h2, h3, h4, h5, h6, .font-display {
-    font-family: 'Clash Display', sans-serif;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  .font-display {
+    font-family: "Clash Display", sans-serif;
     font-weight: 600;
     letter-spacing: -0.03em;
   }
-  
-  .font-mono, code, pre, .mono {
-    font-family: 'JetBrains Mono', monospace;
+
+  .font-mono,
+  code,
+  pre,
+  .mono {
+    font-family: "JetBrains Mono", monospace;
   }
-  
+
   p {
     font-size: 1rem;
     line-height: 1.7;
   }
-  
+
   ::selection {
     background-color: hsl(var(--accent) / 0.3);
     color: hsl(var(--foreground));
@@ -103,13 +112,13 @@
   }
 
   .section-label::before {
-    content: '◆';
+    content: "◆";
     display: block;
     line-height: 1;
     flex-shrink: 0;
     transform: translateY(-1px);
   }
-  
+
   /* Dark Glass Card */
   .glass-card {
     background-color: hsl(var(--surface));
@@ -117,12 +126,12 @@
     border-radius: 1rem;
     transition: all 0.2s ease;
   }
-  
+
   .glass-card:hover {
     background-color: hsl(var(--surface-elevated));
     border-color: hsl(var(--accent) / 0.2);
   }
-  
+
   /* Accent Pill / Tag */
   .accent-pill {
     @apply text-xs font-mono rounded-full px-3 py-1;
@@ -130,31 +139,31 @@
     color: hsl(var(--accent));
     border: 1px solid hsl(var(--accent) / 0.2);
   }
-  
+
   /* CTA Button Primary */
   .btn-primary {
     @apply font-semibold rounded-full px-6 py-3 transition-all duration-150;
     background-color: hsl(var(--accent));
     color: hsl(var(--background));
   }
-  
+
   .btn-primary:hover {
     background-color: hsl(var(--accent) / 0.9);
     transform: scale(1.02);
   }
-  
+
   /* CTA Button Ghost */
   .btn-ghost {
     @apply rounded-full px-6 py-3 transition-all duration-150;
     border: 1px solid hsl(var(--border));
     color: hsl(var(--foreground));
   }
-  
+
   .btn-ghost:hover {
     border-color: hsl(var(--accent) / 0.4);
     color: hsl(var(--accent));
   }
-  
+
   /* Floating Nav */
   .floating-nav {
     @apply fixed top-4 left-1/2 -translate-x-1/2 z-50 rounded-full px-2 py-2 flex gap-1;
@@ -162,22 +171,26 @@
     backdrop-filter: blur(20px) saturate(180%);
     border: 1px solid hsl(var(--accent) / 0.08);
   }
-  
+
   /* Text gradient effect */
   .text-gradient {
-    background: linear-gradient(135deg, hsl(var(--accent)) 0%, hsl(var(--accent-tertiary)) 100%);
+    background: linear-gradient(
+      135deg,
+      hsl(var(--accent)) 0%,
+      hsl(var(--accent-tertiary)) 100%
+    );
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
-  
+
   /* Animated underline */
   .animated-underline {
     position: relative;
   }
-  
+
   .animated-underline::after {
-    content: '';
+    content: "";
     position: absolute;
     bottom: -2px;
     left: 0;
@@ -186,19 +199,19 @@
     background-color: hsl(var(--accent));
     transition: width 0.3s ease;
   }
-  
+
   .animated-underline:hover::after {
     width: 100%;
   }
-  
+
   /* Row hover effect */
   .row-hover {
     position: relative;
     transition: all 0.2s ease;
   }
-  
+
   .row-hover::before {
-    content: '';
+    content: "";
     position: absolute;
     inset: 0;
     background-color: hsl(var(--surface-elevated));
@@ -207,11 +220,11 @@
     border-radius: 0.5rem;
     z-index: -1;
   }
-  
+
   .row-hover:hover::before {
     opacity: 1;
   }
-  
+
   /* Stat chip */
   .stat-chip {
     @apply text-xs font-mono px-3 py-1.5 rounded-full;
@@ -225,7 +238,7 @@
   }
 
   .stat-chip::before {
-    content: '◆';
+    content: "◆";
     color: hsl(var(--accent));
     display: block;
     line-height: 1;
@@ -239,9 +252,9 @@
   .noise-overlay {
     position: relative;
   }
-  
+
   .noise-overlay::before {
-    content: '';
+    content: "";
     position: absolute;
     inset: 0;
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
@@ -249,7 +262,7 @@
     pointer-events: none;
     z-index: 1;
   }
-  
+
   /* Aurora blob background for hero */
   .aurora-blob {
     position: absolute;
@@ -300,64 +313,109 @@
     height: 500px;
     top: 5%;
     right: 15%;
-    background: radial-gradient(circle at center, hsl(166 80% 50% / 0.12) 0%, transparent 65%);
+    background: radial-gradient(
+      circle at center,
+      hsl(166 80% 50% / 0.12) 0%,
+      transparent 65%
+    );
     filter: blur(110px);
     opacity: 1;
     animation: aurora-drift-2 32s ease-in-out infinite reverse;
   }
 
   @keyframes aurora-drift-1 {
-    0%, 100% { transform: translate(0px, 0px) scale(1); }
-    33%       { transform: translate(60px, 80px) scale(1.08); }
-    66%       { transform: translate(-40px, 50px) scale(0.95); }
+    0%,
+    100% {
+      transform: translate(0px, 0px) scale(1);
+    }
+    33% {
+      transform: translate(60px, 80px) scale(1.08);
+    }
+    66% {
+      transform: translate(-40px, 50px) scale(0.95);
+    }
   }
 
   @keyframes aurora-drift-2 {
-    0%, 100% { transform: translate(0px, 0px) scale(1); }
-    40%       { transform: translate(-70px, -60px) scale(1.1); }
-    70%       { transform: translate(50px, 40px) scale(0.92); }
+    0%,
+    100% {
+      transform: translate(0px, 0px) scale(1);
+    }
+    40% {
+      transform: translate(-70px, -60px) scale(1.1);
+    }
+    70% {
+      transform: translate(50px, 40px) scale(0.92);
+    }
   }
 
   @keyframes aurora-drift-3 {
-    0%, 100% { transform: translate(0px, 0px) scale(1); }
-    50%       { transform: translate(-60px, -50px) scale(1.12); }
+    0%,
+    100% {
+      transform: translate(0px, 0px) scale(1);
+    }
+    50% {
+      transform: translate(-60px, -50px) scale(1.12);
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .aurora-blob { animation: none !important; }
-    .float-animation { animation: none !important; }
-    .scroll-indicator { animation: none !important; }
-    .fade-in-up { animation: none !important; opacity: 1 !important; }
+    .aurora-blob {
+      animation: none !important;
+    }
+    .float-animation {
+      animation: none !important;
+    }
+    .scroll-indicator {
+      animation: none !important;
+    }
+    .fade-in-up {
+      animation: none !important;
+      opacity: 1 !important;
+    }
   }
-  
+
   /* Float animation */
   .float-animation {
     animation: float 4s ease-in-out infinite;
   }
-  
+
   @keyframes float {
-    0%, 100% {
+    0%,
+    100% {
       transform: translateY(0);
     }
     50% {
       transform: translateY(-8px);
     }
   }
-  
+
   /* Stagger animation classes */
-  .stagger-1 { animation-delay: 0ms; }
-  .stagger-2 { animation-delay: 50ms; }
-  .stagger-3 { animation-delay: 100ms; }
-  .stagger-4 { animation-delay: 150ms; }
-  .stagger-5 { animation-delay: 200ms; }
-  .stagger-6 { animation-delay: 250ms; }
-  
+  .stagger-1 {
+    animation-delay: 0ms;
+  }
+  .stagger-2 {
+    animation-delay: 50ms;
+  }
+  .stagger-3 {
+    animation-delay: 100ms;
+  }
+  .stagger-4 {
+    animation-delay: 150ms;
+  }
+  .stagger-5 {
+    animation-delay: 200ms;
+  }
+  .stagger-6 {
+    animation-delay: 250ms;
+  }
+
   /* Fade in up animation */
   .fade-in-up {
     animation: fade-in-up 0.5s ease-out forwards;
     opacity: 0;
   }
-  
+
   @keyframes fade-in-up {
     from {
       opacity: 0;
@@ -368,22 +426,26 @@
       transform: translateY(0);
     }
   }
-  
+
   /* Media fade-in — used in lightbox when navigating between pieces */
   .media-fade-in {
     animation: media-fade-in 0.15s ease-out forwards;
   }
 
   @keyframes media-fade-in {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 
   /* Scale in animation */
   .scale-in {
     animation: scale-in 0.3s ease-out forwards;
   }
-  
+
   @keyframes scale-in {
     from {
       opacity: 0;
@@ -394,21 +456,22 @@
       transform: scale(1);
     }
   }
-  
+
   /* Scroll indicator bounce */
   .scroll-indicator {
     animation: scroll-bounce 2s ease-in-out infinite;
   }
-  
+
   @keyframes scroll-bounce {
-    0%, 100% {
+    0%,
+    100% {
       transform: translateY(0);
     }
     50% {
       transform: translateY(8px);
     }
   }
-  
+
   /* Hide scrollbar (used by horizontal scroll strips) */
   .scrollbar-hide {
     -ms-overflow-style: none;
@@ -420,9 +483,11 @@
 
   /* Card lift effect */
   .card-lift {
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
   }
-  
+
   .card-lift:hover {
     transform: translateY(-4px);
     box-shadow: 0 20px 40px -12px hsl(var(--background) / 0.5);


### PR DESCRIPTION
## Summary

- Replace text abbreviations (X, IG, GH, LN) with proper platform icons for X, Instagram, GitHub, and LinkedIn
- Add footer navigation section with all 5 main links (About, Projects, Blog, Art, Movies), each hovering to their per-route accent color
- Redesign footer layout into a structured two-column grid on desktop (contact + social left, navigate right) with labelled sections
- Update footer credit line to "Built with Next.js · Deployed on Vercel"

## Test plan

- [ ] Desktop: two columns render correctly — email/social left, nav right
- [ ] Mobile: sections stack cleanly with proper spacing
- [ ] Each nav link hovers to its correct accent color (mint, emerald, blue, violet, coral)
- [ ] Social icons render and link correctly
- [ ] Email copy button still works
- [ ] Footer credit reads "Built with Next.js · Deployed on Vercel"

🤖 Generated with [Claude Code](https://claude.com/claude-code)