### PR TITLE
feat: add Claude Code vs Cursor blog post

### DIFF
--- a/posts/claude-code-vs-cursor.md
+++ b/posts/claude-code-vs-cursor.md
@@ -1,0 +1,104 @@
+---
+title: "Claude Code vs Cursor: Why I Switched and What I Still Use Cursor For"
+date: "2026-04-07"
+description: "I used Cursor for almost a year before switching to Claude Code for most of my development. Here is an honest breakdown of both tools, what each one does better, and why I now default to Claude."
+category: "Productivity"
+tags: ["productivity", "AI"]
+---
+
+I used Cursor for a long time. It felt like a natural upgrade from VS Code — same editor, same shortcuts, same extensions, but with AI baked in. It was genuinely great at first.
+
+Then I started using Claude Code more seriously, and my setup started to shift. Today I would say about 80% of my development happens through the Claude desktop app or the Claude Code CLI. Cursor is still installed, and I still reach for it sometimes, but it is no longer my default.
+
+Here is what I have learned going back and forth between both.
+
+---
+
+## Where Cursor Started to Fall Short
+
+### Memory and Performance on Larger Repos
+
+The biggest pain point that built up over time was RAM usage. On simpler projects it is fine, but once you are working in a moderately complex repo — multiple packages, lots of TypeScript, heavier dependencies — Cursor starts consuming memory fast. On my MacBook I would regularly see it sitting at 1.5–2GB+ while just idling with a few files open. That adds up when you also have a browser, a terminal, and other tools running.
+
+### Linting, Formatting, and TypeScript Feel Slow
+
+This is a smaller complaint, but it adds friction. TypeScript IntelliSense, ESLint, and Prettier inside Cursor can lag in a way that VS Code handles better with dedicated extension configs. Cursor's AI layer seems to occasionally compete with the language server for resources, and the result is sluggish autocomplete or delayed type errors. If you rely on tight feedback loops with TypeScript, this gets annoying.
+
+### The Agentic Mode Catches Up, But Slowly
+
+Cursor has made huge strides with its composer and agent features, but in practice I found it would get confused on multi-step tasks or start making safe, conservative edits when I wanted it to just go ahead and do the thing. Claude's ability to reason through a longer chain of changes — reading multiple files, understanding the architecture, making coordinated edits — felt noticeably better on complex tasks.
+
+---
+
+## What Made Me Switch to Claude Code
+
+### The Desktop App Is Great for Everyone
+
+If you are someone newer to AI coding tools, the Claude desktop app is honestly one of the most approachable starting points out there. You do not need to configure a terminal or know any flags. You describe what you want, it does the work, you review it. The interface is clean and it does not assume you already know how everything works.
+
+If you are more technical, the CLI (`claude`) works just as well and you can use both interchangeably depending on what you are doing. I will often start something in the desktop app, then drop into the CLI for a task that feels more at home in a terminal. They share the same context and tools, so there is no friction switching.
+
+### Managing Multiple Workstreams with Worktrees
+
+This is one of my favorite things about the Claude Code desktop app. It has built-in support for git worktrees, meaning you can spin up separate isolated environments for different tasks and have them all running at the same time in different tabs. One tab working on a feature branch, another doing a refactor, another investigating a bug — all without them stepping on each other.
+
+For anyone juggling multiple tasks or who wants to keep things cleanly separated, this workflow is a real upgrade over switching branches in a single editor window.
+
+### MCPs Make It Easy to Connect to the Tools You Already Use
+
+Model Context Protocol (MCP) is a way to connect Claude to external tools, and setting it up is genuinely simple. I have Claude connected to Linear, my project management tool, which means I can ask it to pull up open issues, check what is in progress, or even create and update tickets without leaving my workflow.
+
+The practical effect is that Claude can help you plan a feature by reading the actual task spec, not just what you copy-pasted into the chat. That context makes a meaningful difference in the quality of what it produces. You can also connect to databases, documentation sources, or any custom tool your team builds. The integration surface is wide.
+
+### CLAUDE.md and Skills Keep Context Consistent
+
+One of the frustrations with any AI coding tool is re-explaining your project every time you start a new session. Claude Code has a clean solution for this: a `CLAUDE.md` file that lives in your repo. It is just a Markdown file where you document your project setup, architecture decisions, design conventions, and anything else you want Claude to always know about.
+
+Once that is in place, every new session starts with full context. No re-explaining your tech stack, no re-specifying your naming conventions, no repeating which folder structure you use.
+
+Skills work in a similar way — they let you define reusable prompts or workflows that Claude can follow consistently. I use them to standardize how I want Claude to approach certain tasks so results stay predictable across sessions.
+
+### Seeing the Front-End Is a Game Changer
+
+This is the one that convinced me the most as a front-end developer. When I am working on a UI bug or building out a new component, I can have Claude:
+
+1. Spin up the local dev server
+2. Take a screenshot of the current state
+3. Identify what is wrong
+4. Make the fix
+5. Take another screenshot to verify it worked
+
+It is not just reading code — it is actually looking at the rendered result. In the desktop app you can use the built-in preview mode to run the app without leaving the window at all. When a bug is visual (wrong spacing, a layout that breaks at a certain viewport, something that only shows up at runtime), having Claude confirm the fix with its own eyes is a completely different experience from debugging by guessing.
+
+---
+
+## When I Still Reach for Cursor
+
+Cursor has one thing that Claude Code does not match yet: the in-editor code diff experience. When I want to sit down and carefully read through a set of changes, accept or reject individual hunks, or make small manual tweaks to what the AI produced, Cursor's editor interface is still more comfortable. The side-by-side diff, the inline accept/reject buttons, the familiar keyboard shortcuts — it is just ergonomically good for that specific task.
+
+So my current workflow looks roughly like this:
+
+- **Planning and writing code:** Claude Code desktop or CLI
+- **Multi-task / parallel work:** Claude Code worktrees
+- **Front-end debugging:** Claude Code with preview
+- **Carefully reviewing and tweaking AI-generated changes:** Cursor
+
+That last category probably accounts for 20% of my time. The rest has moved over.
+
+---
+
+## Pricing
+
+Both tools have free tiers and paid plans. Cursor Pro is around $20/month. Claude Pro is also $20/month. Claude Max plans go higher if you need more usage. For the amount of work I run through Claude daily, the cost feels worth it by a wide margin.
+
+---
+
+## Which One Should You Use?
+
+If you want an AI coding tool that feels like an upgraded text editor, Cursor is a strong starting point. If you want something that can actually run your project, look at the output, coordinate complex multi-file changes, and connect to the rest of your workflow — Claude Code is where I would point you.
+
+They are not mutually exclusive. Having both installed costs nothing. But if you are going to commit to learning one deeply, I would bet on Claude Code being where things are headed.
+
+---
+
+Hope this gives you a useful picture. 🛠️


### PR DESCRIPTION
## Summary

- Adds new blog post `posts/claude-code-vs-cursor.md` targeting the `claude code vs cursor` search query
- Covers Cursor's RAM/performance pain points, Claude Code's key advantages (worktrees, MCPs, CLAUDE.md, front-end preview), and honest use cases for both
- Includes pricing section and "which should you use" closer for SEO completeness
- Tagged `Productivity` + `AI`, date `2026-04-07`

## Test plan

- [ ] Visit `/blog` and confirm post appears in the list
- [ ] Visit `/blog/claude-code-vs-cursor` and verify formatting, read time, and category pill render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)